### PR TITLE
Add ping controller to application

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,12 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <version>${spring.version}</version>
             <scope>test</scope>

--- a/src/main/java/ru/itmo/sd/deadliner2bot/controller/PingController.java
+++ b/src/main/java/ru/itmo/sd/deadliner2bot/controller/PingController.java
@@ -1,0 +1,19 @@
+package ru.itmo.sd.deadliner2bot.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(path = "/ping")
+@Slf4j
+public class PingController {
+
+    @GetMapping()
+    public ResponseEntity<Object> ping() {
+        log.info("Pinged");
+        return ResponseEntity.ok().build();
+    }
+}


### PR DESCRIPTION
Heroku requires app to be binded to a given port. Bot is a client, so we introduce a server part of the application.